### PR TITLE
Fixed actionSanitizer error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ export const actionSanitizer: (action: Action) => Action =
   action => {
     const meta = (action as InternalAction)[META_SYM]
 
-    return meta.async && meta.state
+    return meta && meta.async && meta.state
       ? ({ ...action, type: `${action.type} [ ${meta.state.toUpperCase()} ]` })
       : action
   }


### PR DESCRIPTION
**version:** 0.13.0

```ts
export const actionSanitizer: (action: Action) => Action =
  action => {
    const meta = (action as InternalAction)[META_SYM]Ьу

    return meta.async && meta.state
      ? ({ ...action, type: `${action.type} [ ${meta.state.toUpperCase()} ]` })
      : action
  }
```

`meta` can be `undefined` and we get an error:

```ts
Uncaught TypeError: Cannot read property 'async' of undefined
```

I added check for meta.


